### PR TITLE
Fixed so pluck returns array vs collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -375,7 +375,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function pluck($value, $key = null)
     {
-        return new static(Arr::pluck($this->items, $value, $key));
+        return (Arr::pluck($this->items, $value, $key));
     }
 
     /**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -375,7 +375,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function pluck($value, $key = null)
     {
-        return (Arr::pluck($this->items, $value, $key));
+        return Arr::pluck($this->items, $value, $key);
     }
 
     /**


### PR DESCRIPTION
Returning the new static is causing the creation of a collection instead of an array.  If the intention is to return an array, need to remove the static call, otherwise change the docs to reflect plucking a collection instead of an array.
